### PR TITLE
Add support for webmozart/assert 1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "php-db/phpdb": "^0.6.0",
-        "webmozart/assert": "^2.0"
+        "webmozart/assert": "^1.12.0 || ^2.0"
     },
     "require-dev": {
         "ext-pdo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd8725e19686a7f5dd3dcaa1544efee1",
+    "content-hash": "9ecf31ece04ecc508c25e296dc99e689",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -263,12 +263,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-db/phpdb.git",
-                "reference": "81844a5699bf397bf044bbe36ea90be361b4a021"
+                "reference": "e037464a435005e04a3fde3c113324c26406ce7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-db/phpdb/zipball/81844a5699bf397bf044bbe36ea90be361b4a021",
-                "reference": "81844a5699bf397bf044bbe36ea90be361b4a021",
+                "url": "https://api.github.com/repos/php-db/phpdb/zipball/e037464a435005e04a3fde3c113324c26406ce7e",
+                "reference": "e037464a435005e04a3fde3c113324c26406ce7e",
                 "shasum": ""
             },
             "require": {
@@ -324,7 +324,7 @@
                 "issues": "https://github.com/php-db/phpdb/issues",
                 "source": "https://github.com/php-db/phpdb"
             },
-            "time": "2026-04-13T01:24:01+00:00"
+            "time": "2026-07-08T05:31:35+00:00"
         },
         {
             "name": "psr/container",
@@ -2436,16 +2436,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -2511,7 +2511,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "staabm/side-effects-detector",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | kinda
| RFC           | no
| QA            | no
| House Keeping | no

### Description

This change, while not necessary to the project itself, allows it to be used with [Mezzio Authentication](https://docs.mezzio.dev/mezzio-authentication) and the related packages that Mezzio Authentication makes use of. Without this change, the package isn't available, as the Mezzio Auth packages don't allow for WebMozart/Assert 2.x, yet.